### PR TITLE
feat!: add target flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ version = "0.1.0"
 dependencies = [
  "cargo-lock",
  "cargo_metadata",
+ "pico-args",
  "serde",
  "serde_json",
 ]
@@ -125,6 +126,12 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cargo-lock = "4.0"
 cargo_metadata = "0.10"
+pico-args = "0.3.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-cargo-lock = "4.0"
 
 [package.metadata.blackjack]
 prefix = "blackjack_crates_io"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ load("@blackjack//:blackjack.bzl", "blackjack")
 blackjack(name = "blackjack")
 ```
 
-Now run `bazel run //:blackjack`. You'll find a newly created `cargo_dependencies.bzl` file next to your `Cargo.toml`.
+Now run `bazel run //:blackjack -- --target <triple>`. The `<triple>` argument value is a Rust target triple. You'll find a newly created `cargo_dependencies.bzl` file next to your `Cargo.toml`.
 
 **Note:** Blackjack pulls in its own `cargo` executable, so you do not need to have it installed.
 
@@ -103,6 +103,3 @@ prefix = "blackjack_crates_io"
 ```
 
 Now instead of `@crates_io_serde//:serde`, use `blackjack_crates_io_serde//:serde`.
-
-# Things that don't work yet (but would gladly accept a PR for)
-* Support for Windows and Mac. For the moment everything assumes your host and target is `x86_64-unknown-linux-gnu`

--- a/blackjack.bzl
+++ b/blackjack.bzl
@@ -9,8 +9,9 @@ def blackjack(name=None, manifest="Cargo.toml"):
       srcs = ["@blackjack//:src/bin/blackjack.rs"],
       aliases = {"@blackjack//:blackjack_lib": "blackjack"},
       deps = [
-          "@blackjack_crates_io_cargo_metadata//:cargo_metadata", 
-          "@blackjack_crates_io_cargo_lock//:cargo_lock", 
+          "@blackjack_crates_io_cargo_lock//:cargo_lock",
+          "@blackjack_crates_io_cargo_metadata//:cargo_metadata",
+          "@blackjack_crates_io_pico_args//:pico_args", 
           "@blackjack//:blackjack_lib",
       ],
       edition = "2018",

--- a/cargo_dependencies.bzl
+++ b/cargo_dependencies.bzl
@@ -334,6 +334,31 @@ rust_library(
     
 
     http_archive(
+        name = "blackjack_crates_io_pico_args",
+        url = "https://crates.io/api/v1/crates/pico-args/0.3.4/download",
+        sha256 = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1",
+        strip_prefix = "pico-args-0.3.4",
+        type = "tar.gz",
+        build_file_content = """
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
+
+rust_library(
+    name = "pico_args",
+    aliases = {},
+    srcs = glob(["**/*.rs"]),
+    crate_type = "lib",
+    deps = [],
+    proc_macro_deps = [],
+    edition = "2018",
+    crate_features = ["default", "eq-separator"],
+    rustc_flags = ["--cap-lints=allow"] + [],
+    visibility = ["//visibility:public"],
+)
+    """,
+    )
+    
+
+    http_archive(
         name = "blackjack_crates_io_proc_macro2_1.0.18",
         url = "https://crates.io/api/v1/crates/proc-macro2/1.0.18/download",
         sha256 = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa",

--- a/src/bin/blackjack.rs
+++ b/src/bin/blackjack.rs
@@ -7,6 +7,11 @@ use std::path::{Path, PathBuf};
 const CARGO_TOML_RUNFILES_PATH: &str = "Cargo.toml";
 const CARGO_RUNFILES_PATH: &str = "external/blackjack_cargo/cargo";
 
+struct Args {
+    /// The Rust target triple used to generate the crate definitions.
+    target: String,
+}
+
 fn workspace_path() -> PathBuf {
     // This is somewhat of an implementation detail
     let mut cargo_toml_path = std::fs::read_link(CARGO_TOML_RUNFILES_PATH)
@@ -29,14 +34,19 @@ fn set_cargo_path(metadata: &mut MetadataCommand) {
 }
 
 fn main() {
+    let mut pico = pico_args::Arguments::from_env();
+    let args = Args {
+        target: pico.value_from_str(["-t", "--target"]).unwrap(),
+    };
+    pico.finish().expect("Unknown CLI arguments specified!");
+
     let workspace_path = workspace_path();
     let cargo_toml_path = workspace_path.join("Cargo.toml");
 
     let mut metadata = MetadataCommand::new();
     metadata.manifest_path(&cargo_toml_path).other_options(vec![
-        // TODO make this configurable
         "--filter-platform".to_string(),
-        "x86_64-unknown-linux-gnu".to_string(),
+        args.target,
     ]);
     set_cargo_path(&mut metadata);
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 set -e
 
-echo | bazel run //:blackjack
+# CI runs on ubuntu-latest
+target=x86_64-unknown-linux-gnu
+
+echo | bazel run //:blackjack -- --target="$target"
 bazel build //:all
 
 pushd tests/popular_crates
-echo | bazel run //:blackjack
+echo | bazel run //:blackjack -- --target="$target"
 bazel build //:crates
 popd
 
 pushd tests/linkc
-echo | bazel run //:blackjack
+echo | bazel run //:blackjack -- --target="$target"
 bazel run //:main
 popd
 
 pushd tests/workspace
-echo | bazel run //:blackjack
+echo | bazel run //:blackjack -- --target="$target"
 bazel run //crate1
 bazel run //crate2
 popd


### PR DESCRIPTION
This commit adds support for specifying the target triple that blackjack
uses when generating the Bazel rules.

BREAKING CHANGE: The `-t,--target` argument is mandatory. Existing
tooling fails to run successfully due to it missing. To achieve the same
behavior as in v0.1.0, the target value should be set to
`x86_64-unknown-linux-gnu`.

Closes #5